### PR TITLE
Update to SwiftOpenAI 3.4

### DIFF
--- a/AIProxyBootstrap.xcodeproj/project.pbxproj
+++ b/AIProxyBootstrap.xcodeproj/project.pbxproj
@@ -369,8 +369,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/jamesrochabrun/SwiftOpenAI";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.0;
+				kind = exactVersion;
+				version = 3.4.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Chat/Chat.xcodeproj/project.pbxproj
+++ b/Chat/Chat.xcodeproj/project.pbxproj
@@ -390,8 +390,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/jamesrochabrun/SwiftOpenAI";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.0;
+				kind = exactVersion;
+				version = 3.4.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Chat/Chat/AppConstants.swift
+++ b/Chat/Chat/AppConstants.swift
@@ -37,13 +37,13 @@ import SwiftData
 import SwiftOpenAI
 
 enum AppConstants {
-#warning("You must change the placeholders below for building and running")
-#if DEBUG && targetEnvironment(simulator)
+    #warning(
+        """
+        You must follow the AIProxy integration guide to build and run on device.
+        Please see https://www.aiproxy.pro/docs/integration-guide.html")
+        """
+    )
     static let openAI: some OpenAIService = OpenAIServiceFactory.service(
-        aiproxyPartialKey: "hardcode_partial_key_here",
-        aiproxyDeviceCheckBypass: "hardcode_device_check_bypass_here")
-#else
-    static let openAI: some OpenAIService = OpenAIServiceFactory.service(
-        aiproxyPartialKey: "hardcode_partial_key_here")
-#endif
+        aiproxyPartialKey: "hardcode_partial_key_here"
+    )
 }

--- a/Classifier/Classifier.xcodeproj/project.pbxproj
+++ b/Classifier/Classifier.xcodeproj/project.pbxproj
@@ -396,8 +396,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/jamesrochabrun/SwiftOpenAI";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.0;
+				kind = exactVersion;
+				version = 3.4.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Classifier/Classifier/AppConstants.swift
+++ b/Classifier/Classifier/AppConstants.swift
@@ -39,14 +39,13 @@ import SwiftOpenAI
 enum AppConstants {
     static let videoSampleQueue = DispatchQueue(label: "com.AIProxyBootstrap.videoSampleQueue")
 
-#warning("You must change the placeholders below for building and running")
-#if DEBUG && targetEnvironment(simulator)
+    #warning(
+        """
+        You must follow the AIProxy integration guide to build and run on device.
+        Please see https://www.aiproxy.pro/docs/integration-guide.html")
+        """
+    )
     static let openAI: some OpenAIService = OpenAIServiceFactory.service(
-        aiproxyPartialKey: "hardcode_partial_key_here",
-        aiproxyDeviceCheckBypass: "hardcode_device_check_bypass_here")
-#else
-    static let openAI: some OpenAIService = OpenAIServiceFactory.service(
-        aiproxyPartialKey: "hardcode_partial_key_here")
-#endif
+        aiproxyPartialKey: "hardcode_partial_key_here"
+    )
 }
-

--- a/Stickers/Stickers.xcodeproj/project.pbxproj
+++ b/Stickers/Stickers.xcodeproj/project.pbxproj
@@ -394,8 +394,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/jamesrochabrun/SwiftOpenAI";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.0;
+				kind = exactVersion;
+				version = 3.4.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Stickers/Stickers/AppConstants.swift
+++ b/Stickers/Stickers/AppConstants.swift
@@ -37,13 +37,13 @@ import SwiftOpenAI
 */
 
 enum AppConstants {
-#warning("You must change the placeholders below for building and running")
-#if DEBUG && targetEnvironment(simulator)
+    #warning(
+        """
+        You must follow the AIProxy integration guide to build and run on device.
+        Please see https://www.aiproxy.pro/docs/integration-guide.html")
+        """
+    )
     static let openAI: some OpenAIService = OpenAIServiceFactory.service(
-        aiproxyPartialKey: "hardcode_partial_key_here",
-        aiproxyDeviceCheckBypass: "hardcode_device_check_bypass_here")
-#else
-    static let openAI: some OpenAIService = OpenAIServiceFactory.service(
-        aiproxyPartialKey: "hardcode_partial_key_here")
-#endif
+        aiproxyPartialKey: "hardcode_partial_key_here"
+    )
 }

--- a/Transcriber/Transcriber.xcodeproj/project.pbxproj
+++ b/Transcriber/Transcriber.xcodeproj/project.pbxproj
@@ -425,8 +425,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/jamesrochabrun/SwiftOpenAI";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.0;
+				kind = exactVersion;
+				version = 3.4.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Transcriber/Transcriber/AppConstants.swift
+++ b/Transcriber/Transcriber/AppConstants.swift
@@ -48,13 +48,13 @@ enum AppConstants {
 
     static let audioSampleQueue = DispatchQueue(label: "com.AIProxyBootstrap.audioSampleQueue")
 
-#warning("You must change the placeholders below for building and running")
-#if DEBUG && targetEnvironment(simulator)
+    #warning(
+        """
+        You must follow the AIProxy integration guide to build and run on device.
+        Please see https://www.aiproxy.pro/docs/integration-guide.html")
+        """
+    )
     static let openAI: some OpenAIService = OpenAIServiceFactory.service(
-        aiproxyPartialKey: "hardcode_partial_key_here",
-        aiproxyDeviceCheckBypass: "hardcode_device_check_bypass_here")
-#else
-    static let openAI: some OpenAIService = OpenAIServiceFactory.service(
-        aiproxyPartialKey: "hardcode_partial_key_here")
-#endif
+        aiproxyPartialKey: "hardcode_partial_key_here"
+    )
 }

--- a/Translator/Translator.xcodeproj/project.pbxproj
+++ b/Translator/Translator.xcodeproj/project.pbxproj
@@ -390,8 +390,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/jamesrochabrun/SwiftOpenAI";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.0;
+				kind = exactVersion;
+				version = 3.4.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Translator/Translator/AppConstants.swift
+++ b/Translator/Translator/AppConstants.swift
@@ -37,13 +37,13 @@ import SwiftOpenAI
 */
 
 enum AppConstants {
-#warning("You must change the placeholders below for building and running")
-#if DEBUG && targetEnvironment(simulator)
+    #warning(
+        """
+        You must follow the AIProxy integration guide to build and run on device.
+        Please see https://www.aiproxy.pro/docs/integration-guide.html")
+        """
+    )
     static let openAI: some OpenAIService = OpenAIServiceFactory.service(
-        aiproxyPartialKey: "hardcode_partial_key_here",
-        aiproxyDeviceCheckBypass: "hardcode_device_check_bypass_here")
-#else
-    static let openAI: some OpenAIService = OpenAIServiceFactory.service(
-        aiproxyPartialKey: "hardcode_partial_key_here")
-#endif
+        aiproxyPartialKey: "hardcode_partial_key_here"
+    )
 }

--- a/Trivia/Trivia.xcodeproj/project.pbxproj
+++ b/Trivia/Trivia.xcodeproj/project.pbxproj
@@ -394,8 +394,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/jamesrochabrun/SwiftOpenAI";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.0;
+				kind = exactVersion;
+				version = 3.4.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Trivia/Trivia/AppConstants.swift
+++ b/Trivia/Trivia/AppConstants.swift
@@ -37,13 +37,13 @@ import SwiftOpenAI
 */
 
 enum AppConstants {
-#warning("You must change the placeholders below for building and running")
-#if DEBUG && targetEnvironment(simulator)
+    #warning(
+        """
+        You must follow the AIProxy integration guide to build and run on device.
+        Please see https://www.aiproxy.pro/docs/integration-guide.html")
+        """
+    )
     static let openAI: some OpenAIService = OpenAIServiceFactory.service(
-        aiproxyPartialKey: "hardcode_partial_key_here",
-        aiproxyDeviceCheckBypass: "hardcode_device_check_bypass_here")
-#else
-    static let openAI: some OpenAIService = OpenAIServiceFactory.service(
-        aiproxyPartialKey: "hardcode_partial_key_here")
-#endif
+        aiproxyPartialKey: "hardcode_partial_key_here"
+    )
 }


### PR DESCRIPTION
The initialization method for AIProxy on SwiftOpenAI changed in version 3.4. To run these projects on simulator, you will need to follow these steps:

* Add an `AIPROXY_DEVICE_CHECK_BYPASS' env variable to Xcode. This token is provided to you in the AIProxy developer dashboard, and is necessary for the iOS simulator to communicate with the AIProxy backend.
  * Type cmd shift , to open up the "Edit Schemes" menu in Xcode
  * Select Run in the sidebar
  * Select Arguments from the top nav
  * Add to the "Environment Variables" section (not the "Arguments Passed on Launch" section) an env variable with name `AIPROXY_DEVICE_CHECK_BYPASS` and value that we provided you in the AIProxy dashboard

See the release announcement on version 3.4 here: https://www.aiproxy.pro/update/2024/06/26/integration-update.html
