### PR TITLE
Update sample apps to latest SwiftOpenAI

### DIFF
--- a/AIProxyBootstrap.xcodeproj/project.pbxproj
+++ b/AIProxyBootstrap.xcodeproj/project.pbxproj
@@ -370,7 +370,7 @@
 			repositoryURL = "https://github.com/jamesrochabrun/SwiftOpenAI";
 			requirement = {
 				kind = exactVersion;
-				version = 3.4.0;
+				version = 3.6.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Chat/Chat.xcodeproj/project.pbxproj
+++ b/Chat/Chat.xcodeproj/project.pbxproj
@@ -391,7 +391,7 @@
 			repositoryURL = "https://github.com/jamesrochabrun/SwiftOpenAI";
 			requirement = {
 				kind = exactVersion;
-				version = 3.4.0;
+				version = 3.6.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Chat/Chat/AppConstants.swift
+++ b/Chat/Chat/AppConstants.swift
@@ -44,6 +44,7 @@ enum AppConstants {
         """
     )
     static let openAI: some OpenAIService = OpenAIServiceFactory.service(
-        aiproxyPartialKey: "hardcode_partial_key_here"
+        aiproxyPartialKey: "hardcode_partial_key_here",
+        aiproxyServiceURL: "hardcode_service_url_here"
     )
 }

--- a/Classifier/Classifier.xcodeproj/project.pbxproj
+++ b/Classifier/Classifier.xcodeproj/project.pbxproj
@@ -397,7 +397,7 @@
 			repositoryURL = "https://github.com/jamesrochabrun/SwiftOpenAI";
 			requirement = {
 				kind = exactVersion;
-				version = 3.4.0;
+				version = 3.6.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Classifier/Classifier/AppConstants.swift
+++ b/Classifier/Classifier/AppConstants.swift
@@ -46,6 +46,7 @@ enum AppConstants {
         """
     )
     static let openAI: some OpenAIService = OpenAIServiceFactory.service(
-        aiproxyPartialKey: "hardcode_partial_key_here"
+        aiproxyPartialKey: "hardcode_partial_key_here",
+        aiproxyServiceURL: "hardcode_service_url_here"
     )
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-# Starter apps for AIProxy
+# Starter apps for AIProxy, using the SwiftOpenAI library
 
-OpenAI sample apps that have AIProxy already included (requires an AIProxy key to build and run). Each app uses the SwiftOpenAI community package to implement API calls.
+Use these apps as a jumping off point to build your own OpenAI experiences on iOS. There are
+six apps, each with a placeholder to add your AIProxy constants (see AppConstants.swift). The
+apps all use the [SwiftOpenAI](https://github.com/jamesrochabrun/SwiftOpenAI) community package
+to implement API calls.
 
 ### Instructions to build and run
 
@@ -16,4 +19,3 @@ OpenAI sample apps that have AIProxy already included (requires an AIProxy key t
 - **Translator** - A simple English to Spanish translation app with text to speech.
 - **Trivia Game** - A trivia game that uses GPT to generate multiple choice questions from a JSON response.
 - **Stickers** - An app that turns a prompt into a kawaii style sticker and extracts the foreground/background using Vision.
-

--- a/Stickers/Stickers.xcodeproj/project.pbxproj
+++ b/Stickers/Stickers.xcodeproj/project.pbxproj
@@ -395,7 +395,7 @@
 			repositoryURL = "https://github.com/jamesrochabrun/SwiftOpenAI";
 			requirement = {
 				kind = exactVersion;
-				version = 3.4.0;
+				version = 3.6.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Stickers/Stickers/AppConstants.swift
+++ b/Stickers/Stickers/AppConstants.swift
@@ -44,6 +44,7 @@ enum AppConstants {
         """
     )
     static let openAI: some OpenAIService = OpenAIServiceFactory.service(
-        aiproxyPartialKey: "hardcode_partial_key_here"
+        aiproxyPartialKey: "hardcode_partial_key_here",
+        aiproxyServiceURL: "hardcode_service_url_here"
     )
 }

--- a/Transcriber/Transcriber.xcodeproj/project.pbxproj
+++ b/Transcriber/Transcriber.xcodeproj/project.pbxproj
@@ -426,7 +426,7 @@
 			repositoryURL = "https://github.com/jamesrochabrun/SwiftOpenAI";
 			requirement = {
 				kind = exactVersion;
-				version = 3.4.0;
+				version = 3.6.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Transcriber/Transcriber/AppConstants.swift
+++ b/Transcriber/Transcriber/AppConstants.swift
@@ -54,7 +54,9 @@ enum AppConstants {
         Please see https://www.aiproxy.pro/docs/integration-guide.html")
         """
     )
+
     static let openAI: some OpenAIService = OpenAIServiceFactory.service(
-        aiproxyPartialKey: "hardcode_partial_key_here"
+        aiproxyPartialKey: "hardcode_partial_key_here",
+        aiproxyServiceURL: "hardcode_service_url_here"
     )
 }

--- a/Translator/Translator.xcodeproj/project.pbxproj
+++ b/Translator/Translator.xcodeproj/project.pbxproj
@@ -391,7 +391,7 @@
 			repositoryURL = "https://github.com/jamesrochabrun/SwiftOpenAI";
 			requirement = {
 				kind = exactVersion;
-				version = 3.4.0;
+				version = 3.6.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Translator/Translator/AppConstants.swift
+++ b/Translator/Translator/AppConstants.swift
@@ -44,6 +44,7 @@ enum AppConstants {
         """
     )
     static let openAI: some OpenAIService = OpenAIServiceFactory.service(
-        aiproxyPartialKey: "hardcode_partial_key_here"
+        aiproxyPartialKey: "hardcode_partial_key_here",
+        aiproxyServiceURL: "hardcode_service_url_here"
     )
 }

--- a/Trivia/Trivia.xcodeproj/project.pbxproj
+++ b/Trivia/Trivia.xcodeproj/project.pbxproj
@@ -395,7 +395,7 @@
 			repositoryURL = "https://github.com/jamesrochabrun/SwiftOpenAI";
 			requirement = {
 				kind = exactVersion;
-				version = 3.4.0;
+				version = 3.6.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Trivia/Trivia/AppConstants.swift
+++ b/Trivia/Trivia/AppConstants.swift
@@ -44,6 +44,7 @@ enum AppConstants {
         """
     )
     static let openAI: some OpenAIService = OpenAIServiceFactory.service(
-        aiproxyPartialKey: "hardcode_partial_key_here"
+        aiproxyPartialKey: "hardcode_partial_key_here",
+        aiproxyServiceURL: "hardcode_service_url_here"
     )
 }


### PR DESCRIPTION
- Bumps SwiftOpenAI version from 3.4.0 to 3.6.1
- Adds `serviceURL` to service initialization. You receive this constant from your AIProxy dashboard